### PR TITLE
Fix issue cache_time serialization issue

### DIFF
--- a/src/KairosDbClient/QueryBuilder.cs
+++ b/src/KairosDbClient/QueryBuilder.cs
@@ -18,6 +18,17 @@ namespace KairosDbClient
         [JsonIgnore]
         public DateTimeOffset? AbsoluteEnd { get; private set; }
         [JsonProperty("cache_time")]
+        private double CacheTimeSeconds {
+            get
+            {
+                if (!CacheTime.HasValue)
+                    return 0;
+                return CacheTime.Value.TotalSeconds;
+
+            }
+            set { CacheTime = TimeSpan.FromSeconds(value); }
+        }
+        [JsonIgnore]
         public TimeSpan? CacheTime { get; private set; }
         [JsonProperty("time_zone")]
         public string TimeZone { get; private set; }


### PR DESCRIPTION
cache_time was incorrectly being serialized as a TimeSpan which causes a 400 error in KairosDB. This fix properly serializes it as a number.
